### PR TITLE
feat: upgrade alpine image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,11 +29,8 @@ RUN npm install -g npm@latest && \
     npm install -g corepack@latest && \
     corepack prepare yarn@stable --activate && \
     corepack enable
-    
-# Disable incremental buildings, not supported by sccache
-ENV CARGO_INCREMENTAL=false
 
 # Configure Rust
 RUN rustup toolchain install stable && \
     rustup target add wasm32-unknown-unknown --toolchain stable && \
-    cargo install -f wasm-bindgen-cli
+    cargo install -f wasm-bindgen-cli@0.2.86

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax = docker/dockerfile:1.5
 
-FROM rust:alpine3.16 as builder
+FROM rust:alpine3.18 as builder
 
 # Install tools and deps
 RUN apk update && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax = docker/dockerfile:1.5
 
-FROM rust:alpine3.18 as builder
+FROM rust:1.71-alpine3.18 as builder
 
 # Install tools and deps
 RUN apk update && \
@@ -29,18 +29,7 @@ RUN npm install -g npm@latest && \
     npm install -g corepack@latest && \
     corepack prepare yarn@stable --activate && \
     corepack enable
-
-# Install sccache for caching
-ENV SCCACHE_VERSION=0.4.2
-RUN if [[ "$TARGETARCH" == "arm64" ]] ; then export SCC_ARCH=aarch64; else export SCC_ARCH=x86_64; fi; \
-    curl -Ls \
-        https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VERSION}/sccache-v${SCCACHE_VERSION}-${SCC_ARCH}-unknown-linux-musl.tar.gz | \
-        tar -C /tmp -xz && \
-        mv /tmp/sccache-*/sccache /usr/local/bin/
-
-# Activate sccache for Rust code
-ENV RUSTC_WRAPPER=/usr/local/bin/sccache
-
+    
 # Disable incremental buildings, not supported by sccache
 ENV CARGO_INCREMENTAL=false
 


### PR DESCRIPTION
Bump rust alpine to the latest image. This is necessary in order to migrate minimum Node.JS SDK to the v18 (LTS)