### PR TITLE
chore: revert sccache back

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,14 @@ RUN npm install -g npm@latest && \
     corepack prepare yarn@stable --activate && \
     corepack enable
 
+# Install sccache for caching
+ENV SCCACHE_VERSION=0.4.2
+RUN if [[ "$TARGETARCH" == "arm64" ]] ; then export SCC_ARCH=aarch64; else export SCC_ARCH=x86_64; fi; \
+    curl -Ls \
+        https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VERSION}/sccache-v${SCCACHE_VERSION}-${SCC_ARCH}-unknown-linux-musl.tar.gz | \
+        tar -C /tmp -xz && \
+        mv /tmp/sccache-*/sccache /usr/local/bin/
+
 # Configure Rust
 RUN rustup toolchain install stable && \
     rustup target add wasm32-unknown-unknown --toolchain stable && \


### PR DESCRIPTION
Revert sccache back in the image as it is being used in the platform build (js-drive, dashmate_helper images)